### PR TITLE
drop checkout step

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -34,9 +34,6 @@ inputs:
 runs:
   using: 'composite'
   steps:
-    - name: Checkout repository
-      uses: actions/checkout@v4
-
     - name: Set JAMCR_USER from token
       shell: bash
       run: |


### PR DESCRIPTION
This checkout step makes including this action into existing workflows difficult as it re-checks out the repo, wiping away any state that's been produced by previous steps. Note: the example we give in the README already includes a checkout step.